### PR TITLE
:wrench: Update Manifest to v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "Ninja Coins",
-    "version": "1.1",
+    "version": "1.2",
     "description": "Change the Santédollars icon to Ninja Coins",
     "content_scripts": [
         {
@@ -25,5 +25,10 @@
             "matches": ["*://www.etreensante.ca/*/bilan/activites"]
         }
     ],
-    "web_accessible_resources": ["assets/ninjacoin.svg", "assets/tlmlogo.svg"]
+    "web_accessible_resources": [
+        {
+	        "resources": ["assets/ninjacoin.svg", "assets/tlmlogo.svg"],
+	        "matches": [ "*://www.etreensante.ca/*" ]
+	    }
+    ]
 }


### PR DESCRIPTION
Manifest version 2 is deprecated, and support will be removed in 2023. See https://developer.chrome.com/blog/mv2-transition/ for more details.